### PR TITLE
Remove myfusionwallet.com

### DIFF
--- a/blockList.json
+++ b/blockList.json
@@ -6179,7 +6179,6 @@
                 "*myeytherwallet.com",
                 "*myezherwallet.com",
                 "*myeztherwallet.com",
-                "*myfusionwallet.com",
                 "*myfusionwallet.net",
                 "*mygetherwallet.com",
                 "*mygtherwallet.com",


### PR DESCRIPTION
myfusionwallet.com is the legit one and belongs to the Fusion protocol.
See https://github.com/fsn-dev/awesome-fusion#wallets
myfusionwallet.net is the malicious one impersonating as myfusionwallet.com.